### PR TITLE
Support runtime compilation

### DIFF
--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,5 +1,6 @@
 tzdata
 r-base-core=4.0.5-1.2004.0
+r-base-dev=4.0.5-1.2004.0
 libcurl3-gnutls
 libxml2
 libgdal26

--- a/packages.csv
+++ b/packages.csv
@@ -133,7 +133,7 @@
 "ggfittext","0.10.0"
 "ggfortify","0.4.15"
 "gggenes","0.5.0"
-"ggh4x","0.2.1"
+"ggh4x","0.2.6"
 "ggplot2","3.4.2"
 "ggpubr","0.4.0"
 "ggrepel","0.9.1"

--- a/renv.lock
+++ b/renv.lock
@@ -2047,13 +2047,15 @@
     },
     "ggh4x": {
       "Package": "ggh4x",
-      "Version": "0.2.1",
+      "Version": "0.2.6",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "5e0b1591bf8489cfacdb5aecf1697626",
+      "Hash": "e82e0bef5e2db1243060afcb8be499ee",
       "Requirements": [
+        "cli",
         "ggplot2",
         "gtable",
+        "lifecycle",
         "rlang",
         "scales",
         "vctrs"

--- a/system-packages.txt
+++ b/system-packages.txt
@@ -1,3 +1,0 @@
-libgit2-dev
-pandoc
-liblz4-dev


### PR DESCRIPTION
This allows users to optimise hot loops by rewriting them in C++ and using the well-known `Rcpp` package.

For some reason this required upgrading `ggh4x` from v0.2.1 to v0.2.6 as the previous version failed to compile.

This increases the total on-disk size of the image from 2549M to 2990M.

Closes #149