### PR TITLE
Add REPOS build arg to docker-compose.yaml

### DIFF
--- a/add-package.sh
+++ b/add-package.sh
@@ -23,7 +23,7 @@ fi
 # update renv.lock 
 cp renv.lock renv.lock.bak
 # cannot use docker-compose run as it mangles the output
-docker run --rm "$IMAGE_TAG" cat /renv/renv.lock > renv.lock
+docker run --platform linux/amd64 --rm "$IMAGE_TAG" cat /renv/renv.lock > renv.lock
 
 echo "$PACKAGE and its dependencies built and cached, renv.lock updated." 
 echo "Rebuilding R image with new renv.lock file." 
@@ -36,4 +36,4 @@ fi
 just test "$IMAGE"
 
 # update packages.csv for backwards compat with current docs
-docker run "$IMAGE" -e 'write.csv(installed.packages()[, c("Package","Version")], row.names=FALSE, file="/dev/stdout")' 2>/dev/null > packages.csv
+docker run --platform linux/amd64 "$IMAGE" -e 'write.csv(installed.packages()[, c("Package","Version")], row.names=FALSE, file="/dev/stdout")' 2>/dev/null > packages.csv

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,6 +23,7 @@ services:
       target: add-package
       args:
        - PACKAGE
+       - REPOS
   rstudio:
     extends: r
     image: rstudio

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,6 +16,7 @@ services:
         - REVISION
         - VERSION
     init: true
+    platform: linux/amd64
   add-package:
     extends: r
     image: "${IMAGE_TAG:-}"
@@ -24,6 +25,7 @@ services:
       args:
        - PACKAGE
        - REPOS
+    platform: linux/amd64
   rstudio:
     extends: r
     image: rstudio

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -eu
 IMAGE=${1:-ghcr.io/opensafely-core/r}
-python3 -c 'import json; print("\n".join(json.load(open("renv.lock"))["Packages"]))' | xargs -I {} echo "library({}, warn.conflicts = FALSE)" > .tests.R
+python3 -c 'import json; print("\n".join(json.load(open("renv.lock"))["Packages"]))' | xargs -I {} echo "if (!library({}, warn.conflicts = FALSE, logical.return = TRUE)) {stop(\"Package {} failed to load, please investigate\")}" > .tests.R
 docker run --platform linux/amd64 --rm -v "$PWD:/tests/" "$IMAGE" /tests/.tests.R

--- a/test.sh
+++ b/test.sh
@@ -2,4 +2,4 @@
 set -eu
 IMAGE=${1:-ghcr.io/opensafely-core/r}
 python3 -c 'import json; print("\n".join(json.load(open("renv.lock"))["Packages"]))' | xargs -I {} echo "library({}, warn.conflicts = FALSE)" > .tests.R
-docker run --rm -v "$PWD:/tests/" "$IMAGE" /tests/.tests.R
+docker run --platform linux/amd64 --rm -v "$PWD:/tests/" "$IMAGE" /tests/.tests.R


### PR DESCRIPTION
Apologies - in my haste earlier I forgot to add the REPOS build arg to add-package in the docker-compose.yaml.

Also I add in `platform linux/amd64` to silence the warnings I get on my Mac.

And I have improved the package loading test to actually error if a package fails to load - bizarrely the default behaviour is to issue a message which includes the text "Error:" but doesn't stop the script.