### PR TITLE
Add languageserver to v1

### DIFF
--- a/v1/packages.md
+++ b/v1/packages.md
@@ -353,6 +353,7 @@ tcltk, tools, and utils) for the respective version of R.
 | relimp                | 1.0-5        | <https://cran.r-project.org/package=relimp>                |
 | relsurv               | 2.2-3        | <https://cran.r-project.org/package=relsurv>               |
 | rematch               | 1.0.1        | <https://cran.r-project.org/package=rematch>               |
+| rematch2              | 2.1.2        | <https://cran.r-project.org/package=rematch2>              |
 | remotes               | 2.2.0        | <https://cran.r-project.org/package=remotes>               |
 | renv                  | 0.16.0       | <https://cran.r-project.org/package=renv>                  |
 | repr                  | 1.1.0        | <https://cran.r-project.org/package=repr>                  |
@@ -408,6 +409,7 @@ tcltk, tools, and utils) for the respective version of R.
 | stringdist            | 0.9.10       | <https://cran.r-project.org/package=stringdist>            |
 | stringi               | 1.4.6        | <https://cran.r-project.org/package=stringi>               |
 | stringr               | 1.4.0        | <https://cran.r-project.org/package=stringr>               |
+| styler                | 1.2.0        | <https://cran.r-project.org/package=styler>                |
 | survey                | 4.1-1        | <https://cran.r-project.org/package=survey>                |
 | survival              | 3.2-3        | <https://cran.r-project.org/package=survival>              |
 | survminer             | 0.4.8        | <https://cran.r-project.org/package=survminer>             |

--- a/v1/packages.md
+++ b/v1/packages.md
@@ -61,6 +61,7 @@ tcltk, tools, and utils) for the respective version of R.
 | cobalt                | 4.4.0        | <https://cran.r-project.org/package=cobalt>                |
 | coda                  | 0.19-3       | <https://cran.r-project.org/package=coda>                  |
 | codetools             | 0.2-16       | <https://cran.r-project.org/package=codetools>             |
+| collections           | 0.3.7        | <https://cran.r-project.org/package=collections>           |
 | colorspace            | 1.4-1        | <https://cran.r-project.org/package=colorspace>            |
 | colourpicker          | 1.0          | <https://cran.r-project.org/package=colourpicker>          |
 | commonmark            | 1.7          | <https://cran.r-project.org/package=commonmark>            |
@@ -75,6 +76,7 @@ tcltk, tools, and utils) for the respective version of R.
 | credentials           | 1.3.0        | <https://cran.r-project.org/package=credentials>           |
 | crosstalk             | 1.1.0.1      | <https://cran.r-project.org/package=crosstalk>             |
 | curl                  | 4.3          | <https://cran.r-project.org/package=curl>                  |
+| cyclocomp             | 1.1.1        | <https://cran.r-project.org/package=cyclocomp>             |
 | dagitty               | 0.3-4        | <https://cran.r-project.org/package=dagitty>               |
 | data.table            | 1.13.0       | <https://cran.r-project.org/package=data.table>            |
 | date                  | 1.2-39       | <https://cran.r-project.org/package=date>                  |
@@ -216,6 +218,7 @@ tcltk, tools, and utils) for the respective version of R.
 | ks                    | 1.11.7       | <https://cran.r-project.org/package=ks>                    |
 | labeling              | 0.3          | <https://cran.r-project.org/package=labeling>              |
 | labelled              | 2.7.0        | <https://cran.r-project.org/package=labelled>              |
+| languageserver        | 0.3.6        | <https://cran.r-project.org/package=languageserver>        |
 | later                 | 1.1.0.1      | <https://cran.r-project.org/package=later>                 |
 | lattice               | 0.20-41      | <https://cran.r-project.org/package=lattice>               |
 | latticeExtra          | 0.6-29       | <https://cran.r-project.org/package=latticeExtra>          |
@@ -223,6 +226,7 @@ tcltk, tools, and utils) for the respective version of R.
 | lazyeval              | 0.2.2        | <https://cran.r-project.org/package=lazyeval>              |
 | lcmm                  | 2.0.0        | <https://cran.r-project.org/package=lcmm>                  |
 | lifecycle             | 1.0.3        | <https://cran.r-project.org/package=lifecycle>             |
+| lintr                 | 3.1.2        | <https://cran.r-project.org/package=lintr>                 |
 | listenv               | 0.8.0        | <https://cran.r-project.org/package=listenv>               |
 | lme4                  | 1.1-23       | <https://cran.r-project.org/package=lme4>                  |
 | lmtest                | 0.9-37       | <https://cran.r-project.org/package=lmtest>                |
@@ -360,6 +364,7 @@ tcltk, tools, and utils) for the respective version of R.
 | reprex                | 0.3.0        | <https://cran.r-project.org/package=reprex>                |
 | reshape               | 0.8.8        | <https://cran.r-project.org/package=reshape>               |
 | reshape2              | 1.4.4        | <https://cran.r-project.org/package=reshape2>              |
+| rex                   | 1.2.1        | <https://cran.r-project.org/package=rex>                   |
 | rgdal                 | 1.5-16       | <https://cran.r-project.org/package=rgdal>                 |
 | rgeos                 | 0.5-3        | <https://cran.r-project.org/package=rgeos>                 |
 | rio                   | 0.5.16       | <https://cran.r-project.org/package=rio>                   |
@@ -460,6 +465,7 @@ tcltk, tools, and utils) for the respective version of R.
 | xgboost               | 1.7.5.1      | <https://cran.r-project.org/package=xgboost>               |
 | XML                   | 3.99-0.6     | <https://cran.r-project.org/package=XML>                   |
 | xml2                  | 1.3.2        | <https://cran.r-project.org/package=xml2>                  |
+| xmlparsedata          | 1.0.5        | <https://cran.r-project.org/package=xmlparsedata>          |
 | xtable                | 1.8-4        | <https://cran.r-project.org/package=xtable>                |
 | xts                   | 0.12-0       | <https://cran.r-project.org/package=xts>                   |
 | yaml                  | 2.2.1        | <https://cran.r-project.org/package=yaml>                  |

--- a/v1/renv.lock
+++ b/v1/renv.lock
@@ -1145,6 +1145,14 @@
       "Hash": "89cf4b8207269ccf82fbeb6473fd662b",
       "Requirements": []
     },
+    "collections": {
+      "Package": "collections",
+      "Version": "0.3.7",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "90a0eda114ab0bef170ddbf5ef0cd93f",
+      "Requirements": []
+    },
     "colorspace": {
       "Package": "colorspace",
       "Version": "1.4-1",
@@ -1290,6 +1298,20 @@
       "Repository": "CRAN",
       "Hash": "2b7d10581cc730804e9ed178c8374bd6",
       "Requirements": []
+    },
+    "cyclocomp": {
+      "Package": "cyclocomp",
+      "Version": "1.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "cdc4a473222b0112d4df0bcfbed12d44",
+      "Requirements": [
+        "callr",
+        "crayon",
+        "desc",
+        "remotes",
+        "withr"
+      ]
     },
     "dagitty": {
       "Package": "dagitty",
@@ -2889,6 +2911,27 @@
         "vctrs"
       ]
     },
+    "languageserver": {
+      "Package": "languageserver",
+      "Version": "0.3.6",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "50c873d1859d0f7143906ca7419d534e",
+      "Requirements": [
+        "R6",
+        "callr",
+        "collections",
+        "desc",
+        "fs",
+        "jsonlite",
+        "lintr",
+        "repr",
+        "stringi",
+        "styler",
+        "xml2",
+        "xmlparsedata"
+      ]
+    },
     "later": {
       "Package": "later",
       "Version": "1.1.0.1",
@@ -2966,6 +3009,24 @@
         "cli",
         "glue",
         "rlang"
+      ]
+    },
+    "lintr": {
+      "Package": "lintr",
+      "Version": "3.1.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "08cff46381a242d44c0d8dd0aabd9f71",
+      "Requirements": [
+        "backports",
+        "codetools",
+        "cyclocomp",
+        "digest",
+        "glue",
+        "knitr",
+        "rex",
+        "xml2",
+        "xmlparsedata"
       ]
     },
     "listenv": {
@@ -4274,6 +4335,16 @@
         "stringr"
       ]
     },
+    "rex": {
+      "Package": "rex",
+      "Version": "1.2.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ae34cd56890607370665bee5bd17812f",
+      "Requirements": [
+        "lazyeval"
+      ]
+    },
     "rgdal": {
       "Package": "rgdal",
       "Version": "1.5-16",
@@ -5451,6 +5522,14 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "d4d71a75dd3ea9eb5fa28cc21f9585e2",
+      "Requirements": []
+    },
+    "xmlparsedata": {
+      "Package": "xmlparsedata",
+      "Version": "1.0.5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "45e4bf3c46476896e821fc0a408fb4fc",
       "Requirements": []
     },
     "xtable": {

--- a/v1/renv.lock
+++ b/v1/renv.lock
@@ -706,6 +706,13 @@
       "Version": "0.2.1",
       "Source": "Repository",
       "Repository": "CRAN",
+      "RemoteType": "standard",
+      "RemotePkgRef": "assertthat",
+      "RemoteRef": "assertthat",
+      "RemoteRepos": "https://cloud.r-project.org",
+      "RemoteReposName": "CRAN",
+      "RemotePkgPlatform": "source",
+      "RemoteSha": "0.2.1",
       "Hash": "50c838a310445e954bc13f26f26a6ecf",
       "Requirements": []
     },
@@ -1339,10 +1346,11 @@
       "Version": "0.0.0.9000",
       "Source": "Repository",
       "Repository": "https://remlapmot.r-universe.dev",
+      "RemoteType": "repository",
       "RemoteUrl": "https://github.com/wjchulme/dd4d",
       "RemoteRef": "HEAD",
       "RemoteSha": "291283fd0620d458584108b05d9237104e060c31",
-      "Hash": "95f653ca37fc7eca41757f141f4374a9",
+      "Hash": "23178f77d596f93597b32c0c19282024",
       "Requirements": [
         "dagitty",
         "dplyr",
@@ -4189,6 +4197,16 @@
       "Hash": "c66b930d20bb6d858cd18e1cebcfae5c",
       "Requirements": []
     },
+    "rematch2": {
+      "Package": "rematch2",
+      "Version": "2.1.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "76c9e04c712a05848ae7a23d2f170a40",
+      "Requirements": [
+        "tibble"
+      ]
+    },
     "remotes": {
       "Package": "remotes",
       "Version": "2.2.0",
@@ -4818,6 +4836,25 @@
         "glue",
         "magrittr",
         "stringi"
+      ]
+    },
+    "styler": {
+      "Package": "styler",
+      "Version": "1.2.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "7787dacaca761c15c514197f545111d8",
+      "Requirements": [
+        "backports",
+        "cli",
+        "magrittr",
+        "purrr",
+        "rematch2",
+        "rlang",
+        "rprojroot",
+        "tibble",
+        "withr",
+        "xfun"
       ]
     },
     "survMisc": {


### PR DESCRIPTION
This adds the languageserver <https://cran.r-project.org/package=languageserver> package to r:v1/r:latest (for language server integration with the [VSCode R extension](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r)). This is the newest version of it we can install without updating any dependency packages.

Unfortunately without updating dependency packages the httpgd package https://cran.r-project.org/package=httpgd (provides nice windows of plots in VSCode) won't install (hence why it's not included in this).