### PR TITLE
Delete mention of v1/packages.csv accidentally left in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ just publish VERSION
 ### Commit changes to this repository
 
 Commit and push the small resulting change (should only be a few extra
-lines under v1 in _v1/packages.csv_, _v1/packages.md_, and _v1/renv.lock_; and under v2 in _v2/packages.toml_, _v2/packages.md_, and _v2/pkg.lock_) to a branch, then get the changes
+lines under v1 in _v1/packages.md_ and _v1/renv.lock_; and under v2 in _v2/packages.toml_, _v2/packages.md_, and _v2/pkg.lock_) to a branch, then get the changes
 merged via pull request.
 
 The review is a trivial exercise because the Docker image has already been


### PR DESCRIPTION
This deletes the mention of v1/packages.csv I accidentally left in the README.