### PR TITLE
In rstudio-server enable auto_save_on_blur and auto_save_on_idle

### DIFF
--- a/rstudio/rstudio-entrypoint.sh
+++ b/rstudio/rstudio-entrypoint.sh
@@ -21,9 +21,14 @@ if [ $(find /workspace -type f -name "*.Rproj" | wc -w) -eq 1 ]; then
   cat /home/rstudio/rstudio-rprofile.R >> /home/rstudio/.Rprofile
 fi
 
-# Set file line endings as crlf if docker run from Windows
+# Set RStudio session user settings
+#  - Enable autosave on blur - auto save when editor loses focus
+#  - Enable autosave on idle - commit changes to documents on idle
+#  - Set file line endings as crlf if docker run from Windows
 if [ "$HOSTPLATFORM" = "win32" ] || [ "$HOSTPLATFORM" = "windows" ]; then
-  echo -e "{\n\t\"line_ending_conversion\": \"windows\"\n}" >> /etc/rstudio/rstudio-prefs.json
+  echo -e "{\n\t\"line_ending_conversion\": \"windows\",\n\t\"auto_save_on_blur\": true,\n\t\"auto_save_on_idle\": \"commit\"\n}" > /etc/rstudio/rstudio-prefs.json
+else
+  echo -e "{\n\t\"auto_save_on_blur\": true,\n\t\"auto_save_on_idle\": \"commit\"\n}" > /etc/rstudio/rstudio-prefs.json  
 fi
 
 # Start RStudio Server session in foreground


### PR DESCRIPTION
This enables these settings to match those in the Codespaces RStudio.

One additional point for consideration: by default the idle time before an autosave is only 1 second. Should we make that slightly longer (would just need to additionally set `auto_save_idle_ms` as per <https://docs.posit.co/ide/server-pro/reference/session_user_settings.html>)??

![CleanShot 2025-01-30 at 08 36 49@2x](https://github.com/user-attachments/assets/fdd3fadd-a4e3-47ee-8880-5666eeb04138)
