### PR TITLE
Bump rstudio-server in v1 and v2

### DIFF
--- a/v1/env
+++ b/v1/env
@@ -1,4 +1,4 @@
 MAJOR_VERSION=v1
 BASE=20.04
 RSTUDIO_BASE_URL=https://download2.rstudio.org/server/focal/amd64/
-RSTUDIO_DEB=rstudio-server-2024.09.0-375-amd64.deb
+RSTUDIO_DEB=rstudio-server-2024.12.1-563-amd64.deb

--- a/v2/env
+++ b/v2/env
@@ -1,6 +1,6 @@
 MAJOR_VERSION=v2
 BASE=22.04
 RSTUDIO_BASE_URL=https://download2.rstudio.org/server/jammy/amd64/
-RSTUDIO_DEB=rstudio-server-2024.12.0-467-amd64.deb
+RSTUDIO_DEB=rstudio-server-2024.12.1-563-amd64.deb
 CRAN_DATE=2025-01-30
 REPOS=https://packagemanager.posit.co/cran/__linux__/jammy/${CRAN_DATE}


### PR DESCRIPTION
A new version of RStudio Desktop (and therefore rstudio-server as well) was released on 13th Feb.

I've bumped it in both v1 and v2.