### PR TITLE
Settings to allow users to conveniently install R packages for use in the r:v2 and rstudio:v2 images

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,0 +1,215 @@
+# r-docker
+
+Docker image for running R code in OpenSAFELY, both locally and in production.
+And Docker image for running an rstudio-server session (i.e., RStudio in a browser window) locally or in a Codespace.
+
+## Installation requirements to build this image
+
+* docker
+* docker compose
+* [just](https://github.com/casey/just)
+
+And the tests additionally require
+
+* curl
+* python3
+
+## Building
+
+```sh
+just build VERSION
+```
+
+where `VERSION` is either v1 or v2.
+
+Under the hood, this builds `VERSION/Dockerfile` using docker compose and buildkit.
+
+### Building on GitHub Actions
+
+The v1 image is built on GitHub Actions when there is a new commit on main (i.e., when a PR is merged). Typically, the build takes approximately 2 hours.
+
+The v2 image is built on GitHub Actions when there is a new commit on a branch. Typically, the build takes approximately 5 minutes.
+
+### Building locally
+
+In v1, we currently build a lot of packages, so an initial build on a fresh checkout
+can take a long time (e.g. an hour).  However, to alleviate this, the
+v1/Dockerfile is carefully designed to use local buildkit cache, so subsequent
+rebuilds should be very fast.
+
+In v2, where possible we install binary R packages for Linux from the Posit Public Package Manager (PPPM). And we use the pak package to install packages. This has several advantages including parallel downloads of packages. Therefore, building the v2 image only takes approx. 5 minutes, which is orders of magnitude faster than building the v1 image.
+
+## Adding new packages
+
+### Confirm that the package is suitable to add
+
+Before adding a package, check with an OpenSAFELY team member with R
+experience to approve the package.
+
+### Install the package within Docker
+
+#### Under v1
+
+To add a package, by default it will be installed from CRAN.
+
+```sh
+just add-package-v1 PACKAGE
+```
+
+If you need to install a package from another CRAN-like repository, specify its URL as the REPOS argument.
+
+```sh
+just add-package-v1 PACKAGE REPOS
+```
+
+This will attempt to install and build the package and its dependencies, and
+update the _v1/renv.lock_. It will then rebuild the R image with the new lock file
+and test it.
+
+#### Under v2
+
+Add a new section for the new package/s to _v2/packages.toml_. If all the packages are from CRAN then the section should be structured as follows.
+
+```toml
+[relevant-section-title]
+packages = ["package-name-1", "package-name-2"]
+comment = "Explanatory comment about why the package/s are being added."
+```
+
+If the package is not on CRAN please add it to the <https://opensafely-core.r-universe.dev> by adding it to _packages.json_ in the registry repository <https://github.com/opensafely-core/opensafely-core.r-universe.dev>. If the package only contains R code enter the relevant Linux binary package URL, as an additional `repos` key-value pair in the new section in _v2/packages.toml_, currently this is done as follows.
+
+```toml
+repos = "https://opensafely-core.r-universe.dev/bin/linux/noble/4.4/"
+```
+
+However, if the package contains code to be compiled (such as C, C++, Rust, etc.) please add the R-Universe source package URL as follows (this is because on R-Universe Linux binary packages are built on Ubuntu Noble Numbat whereas the r:v2 image is currently built on Ubuntu Jammy Jellyfish; when they use the same version of Ubuntu the Linux binary package URL above can be used for all packages).
+
+```toml
+repos = "https://opensafely-core.r-universe.dev/"
+```
+
+If the package requires any runtime dependencies add those to _v2/dependencies.txt_
+
+Then build the v2 image.
+
+```sh
+just build v2
+```
+
+### Publishing the images
+
+The images are now published by the GitHub Actions workflow.
+
+#### Publishing the images from your machine
+
+Push the new Docker image to Github Container Registry
+
+You will need to configure authentication to GitHub's container registry first.
+See [GitHub's documentation](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry).
+
+When you have authentication configured, run:
+
+```sh
+just publish VERSION
+```
+
+### Commit changes to this repository
+
+Commit and push the small resulting change (should only be a few extra
+lines under v1 in _v1/packages.md_ and _v1/renv.lock_; and under v2 in _v2/packages.toml_, _v2/packages.md_, and _v2/pkg.lock_) to a branch, then get the changes
+merged via pull request.
+
+### Deploy the new Docker image
+
+The updated image will need pulling into production. This is covered
+separately in the tech team manual. If you don't have access, ask in
+`#tech`.
+
+### Troubleshooting
+
+#### System dependencies
+
+If the package requires any system build dependencies (e.g. -dev packages with
+headers), they should be added to `VERSION/build-dependencies.txt`. If it requires
+runtime dependencies, they should be added to `VERSION/dependencies.txt`. Packages
+don't advertise their system dependencies, so you may need to figure them out
+by trying to add the package and reading any error output on failure.
+
+#### Installing an older version in the v1 image only
+
+If the package still fails to build, you may be able to install an older version.
+
+Find a previous version at `https://cran.r-project.org/src/contrib/Archive/{PACKAGE}/`, and attempt to install it specifically with
+
+```sh
+just add-package-v1 PACKAGE@VERSION
+```
+
+## Building, testing, and publishing the rstudio image
+
+The rstudio image is based on the r image including rstudio-server. To build run
+
+```sh
+just build-rstudio VERSION
+```
+
+To test that rstudio-server appears at `http://localhost:8787` run
+
+```sh
+just test-rstudio VERSION
+```
+
+And then push the new rstudio image to the GitHub container registry with
+
+```sh
+just publish-rstudio VERSION
+```
+
+## How to update the version of R and the packages
+
+In v2, we choose a date from which to install the packages from CRAN, we strongly recommend that the version of R in the image was the release version of R on this date. R release dates can be found on the [R wikipedia page](https://en.wikipedia.org/wiki/R_(programming_language)#Version_names).
+
+In v2, when installing packages we use a Posit Public Package Manager (PPPM) snapshot repository on the chosen `CRAN_DATE`.
+
+We use a fixed date because CRAN follows a rolling release model.
+As such we know that on a particular date CRAN has tested these package versions with the release version of R.
+Hence this is an extremely stable approach to choosing a set of package versions.
+And we can add additional packages at their versions on this date reliably (and without updating dependency packages already included in the image).
+
+The CRAN apt repository for R is available [here](https://cran.r-project.org/bin/linux/ubuntu/jammy-cran40/) (note you may need to amend the Ubuntu codename in the URL if using a newer base image), find the package number you require and edit the number in _v2/dependencies.txt_ and _v2/build-dependencies.txt_.
+
+Then amend the `CRAN_DATE` and `REPOS` arguments in _v2/env_.
+
+To update run
+
+```sh
+just build v2
+```
+
+To test the updated image run
+
+```sh
+just test v2
+```
+
+### How to choose a version of R and CRAN date
+
+Choose a version of R.
+
+Choose a CRAN date when that version of R was the current version of R.
+
+We follow a very similar approach to the versioned stack of the Rocker project. They list their R versions and CRAN dates on their [wiki](https://github.com/rocker-org/rocker-versioned2/wiki/Versions).
+
+We recommend not choosing a date within the first week of a new version of R being released, because there may be alot of packages updated on CRAN during this time.
+
+You then need to check that a PPPM snapshot repository exists for your chosen date. Navigate to <https://p3m.dev/client/#/repos/cran/setup> and inspect your chosen date. Set this date as the `REPOS` variable in _v2/env_.
+
+If you choose a version of R that is not the current version of R we recommend following the Rocker approach and choosing the CRAN date as the day before the next version of R was released. For example, if choosing R 4.4.1, R 4.4.2 was released on 2024-10-31 therefore we would choose 2024-10-30 as the CRAN date. Or as is the case here we are using the current version of R, therefore we choose the latest available date on PPPM as the CRAN date.
+
+You can find out when the next release of R is scheduled for on the [R developer page](https://developer.r-project.org/).
+
+We set the `HTTPUserAgent` in the appropriate places so that we obtain binary R packages for Linux from the PPPM. There is additional information about this on the [PPPM website](https://p3m.dev/__docs__/admin/serving-binaries/#binary-user-agents).
+
+## Differences between packages included in the v1 and v2 images
+
+In v2, compared to v1, several packages have either been superseeded by other packages or have been removed from CRAN. These include dummies, maptools (if required terra could be provided as a replacement), mnlogit, rgdal, and rgeos (the sf package is still included which acts as a replacement for rgdal and rgeos). Several additional packages such as sjPlot have been provided due to requests.

--- a/README.md
+++ b/README.md
@@ -1,219 +1,87 @@
-# r-docker
+# OpenSAFELY R and RStudio Runtime Images
 
-Docker image for running R code in OpenSAFELY, both locally and in production.
+This repo manages the Docker image for the OpenSAFELY R runtime and rstudio-server. These
+images are based on a base Ubuntu LTS version, and come pre-installed with
+a set of standard R packages.
 
-## Installation requirements to build this image
+The current latest version is `v2`, and you should use that unless you have
+a specific reason. You can use it in your `project.yaml` like so:
 
-* docker
-* docker compose
-* [just](https://github.com/casey/just)
+```
+actions:
+  my_action:
+    run: r:v2 analysis/my_script.R
+```
 
-And the tests additionally require
-
-* curl
-* python3
-
-## Building
+The rstudio images are designed for use with `opensafely launch`. For example, to launch an rstudio-server session (i.e., RStudio running in a browser window) run the following in a Terminal from your research repository.
 
 ```sh
-just build VERSION
+opensafely launch rstudio:v2
 ```
 
-where `VERSION` is either v1 or v2.
+## Version List
 
-Under the hood, this builds `VERSION/Dockerfile` using docker compose and buildkit.
+Current available versions for the r image, in reverse chronological order:
 
-In v1, we currently build a lot of packages, so an initial build on a fresh checkout
-can take a long time (e.g. an hour).  However, to alleviate this, the
-v1/Dockerfile is carefully designed to use local buildkit cache, so subequent
-rebuilds should be very fast.
+ - v2: Ubuntu 22.04 and R 4.4.3 - [full package list](v2/packages.md)
+ - v1: Ubuntu 20.04 and R 4.0.5 - [full package list](v1/packages.md) - please note that v1 is deprecated, new projects should use r:v2.
 
-In v2, where possible we install binary R packages for Linux from the Posit Public Package Manager (PPPM). And we use the pak package to install packages. This has several advantages including parallel downloads of packages. Therefore, building the v2 image only takes approx. 5 minutes, which is orders of magnitude faster than building the v1 image.
+Current available versions for the rstudio image, in reverse chronological order:
 
-## Adding new packages
+ - v2: rstudio-server running r:v2
+ - v1: rstudio-server running r:v1
 
-:warning: To do this you will need:
+### Legacy version: `latest`
 
- * Enough bandwidth to comfortably push potentionally gigabytes worth of
-   Docker layers.
- * (Under v1) Several hours worth of CPU time to re-compile all the packages (if
-   this is the first time you've done this and don't have them cached
-   locally).
- * Push access to ghcr.io.
+Initially, OpenSAFELY only had one version of the r image. This is the
+`v1` image, but was originally published under the `:latest` tag. You can use
+either `v1` or `latest` - they are the same version.  In future, we may
+deprecate the `latest` tag and require users to update their `project.yaml` to
+use `v1` instead of `latest`.
 
-If you don't have all these things then please don't start.
 
-### Confirm that the package is suitable to add
+## Update Policy
 
-Before adding a package, check with an OpenSAFELY team member with R
-experience to approve the package.
+### R Package Versions
 
-### Install the package within Docker
+We do not plan to add anymore packages to the v1 image.
 
-#### Under v1
+For the v2 image, the versions of R packages from CRAN tied to a CRAN date.
+We can easily install any additional package from the same CRAN date.
+Additional packages may be requested by creating an issue in the repo.
+In the v2 image you can request packages that are not on CRAN.
 
-To add a package, by default it will be installed from CRAN.
+Occasionally, we will create a new major version of the image with all packages
+updated to their latest version. We may also possibly remove old and uneeded
+pacakges at this point.  A new major version is a chance to make backwards
+incompatible changes, which is occasionally needed.
 
-```sh
-just add-package-v1 PACKAGE
+### User installed R packages
+
+Especially when working in say a Codespace using the rstudio:v2 image you may wish to add some packages for your post release analysis.
+The v2 images are configured to allow you to install your own packages, which will be saved to a _.local-packages/r/v2_ directory in your research repository.
+If the packages is on CRAN, to do this simply run the following.
+
+```r
+install.packages("PACKAGENAME")
 ```
 
-If you need to install a package from another CRAN-like repository, specify its URL as the REPOS argument.
+You may also install packages from a remote repository, for example if the package is on GitHub only, to do this install the remotes package first as follows.
 
-```sh
-just add-package-v1 PACKAGE REPOS
+```r
+install.packages("remotes")
+remotes::install_github("USERNAME/REPONAME")
 ```
 
-This will attempt to install and build the package and its dependencies, and
-update the _v1/renv.lock_. It will then rebuild the R image with the new lock file
-and test it.
+Please note that user installed packages are temporary.
+They are not saved into your research repository, nor are they saved in the Docker image.
+You will need to reinstall user installed packages each time you create a new Codespace, or if you setup your repository on a different computer.
 
-Note that the first time you do this it will need to compile every
-included R package (because you won't have the R package builds cached
-locally). This can take **several hours**. (When we solve the caching
-problem here we'll be able to do this all in CI.)
+### Operating System Packages
 
-#### Under v2
+We *do* update the underlying operating system packages on a regular basis, in
+order to apply security updates to the base system. It is very unlikely that
+this will break backwards compatibility, as these are a small set very
+conservative set of updates to address security issues.
 
-Add a new section for the new package/s to _v2/packages.toml_. If all the packages are from CRAN then the section should be structured as follows.
-
-```toml
-[relevant-section-title]
-packages = ["package-name-1", "package-name-2"]
-comment = "Explanatory comment about why the package/s are being added."
-```
-
-If the package is not on CRAN please add it to the <https://opensafely-core.r-universe.dev> by adding it to _packages.json_ in the registry repository <https://github.com/opensafely-core/opensafely-core.r-universe.dev>. If the package only contains R code enter the relevant Linux binary package URL, as an additional `repos` key-value pair in the new section in _v2/packages.toml_, currently this is done as follows.
-
-```toml
-repos = "https://opensafely-core.r-universe.dev/bin/linux/noble/4.4/"
-```
-
-However, if the package contains code to be compiled (such as C, C++, Rust, etc.) please add the R-Universe source package URL as follows (this is because on R-Universe Linux binary packages are built on Ubuntu Noble Numbat whereas the r:v2 image is currently built on Ubuntu Jammy Jellyfish; when they use the same version of Ubuntu the Linux binary package URL above can be used for all packages).
-
-```toml
-repos = "https://opensafely-core.r-universe.dev/"
-```
-
-If the package requires any runtime dependencies add those to _v2/dependencies.txt_
-
-Then build the v2 image.
-
-```sh
-just build v2
-```
-
-### Push the new Docker image to Github Container Registry
-
-You will need to configure authentication to GitHub's container registry first.
-See [GitHub's documentation](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry).
-
-When you have authentication configured, run:
-
-```sh
-just publish VERSION
-```
-
-### Commit changes to this repository
-
-Commit and push the small resulting change (should only be a few extra
-lines under v1 in _v1/packages.md_ and _v1/renv.lock_; and under v2 in _v2/packages.toml_, _v2/packages.md_, and _v2/pkg.lock_) to a branch, then get the changes
-merged via pull request.
-
-The review is a trivial exercise because the Docker image has already been
-pushed to GitHub.
-
-### Deploy the new Docker image
-
-The updated image will need pulling into production. This is covered
-separately in the tech team manual. If you don't have access, ask in
-`#tech`.
-
-### Troubleshooting
-
-#### System dependencies
-
-If the package requires any system build dependencies (e.g. -dev packages with
-headers), they should be added to `VERSION/build-dependencies.txt`. If it requires
-runtime dependencies, they should be added to `VERSION/dependencies.txt`. Packages
-don't advertise their system dependencies, so you may need to figure them out
-by trying to add the package and reading any error output on failure.
-
-#### Installing an older version in the v1 image only
-
-If the package still fails to build, you may be able to install an older version.
-
-Find a previous version at `https://cran.r-project.org/src/contrib/Archive/{PACKAGE}/`, and attempt to install it specifically with
-
-```sh
-just add-package-v1 PACKAGE@VERSION
-```
-
-## Building, testing, and publishing the rstudio image
-
-The rstudio image is based on the r image including rstudio-server. To build run
-
-```sh
-just build-rstudio VERSION
-```
-
-To test that rstudio-server appears at `http://localhost:8787` run
-
-```sh
-just test-rstudio VERSION
-```
-
-And then push the new rstudio image to the GitHub container registry with
-
-```sh
-just publish-rstudio VERSION
-```
-
-## How to update the version of R and the packages
-
-In v2, we choose a date from which to install the packages from CRAN, we strongly recommend that the version of R in the image was the release version of R on this date. R release dates can be found on the [R wikipedia page](https://en.wikipedia.org/wiki/R_(programming_language)#Version_names).
-
-In v2, when installing packages we use a Posit Public Package Manager (PPPM) snapshot repository on the chosen `CRAN_DATE`.
-
-We use a fixed date because CRAN follows a rolling release model.
-As such we know that on a particular date CRAN has tested these package versions with the release version of R.
-Hence this is an extremely stable approach to choosing a set of package versions.
-And we can add additional packages at their versions on this date reliably (and without updating dependency packages already included in the image).
-
-The CRAN apt repository for R is available [here](https://cran.r-project.org/bin/linux/ubuntu/jammy-cran40/) (note you may need to amend the Ubuntu codename in the URL if using a newer base image), find the package number you require and edit the number in _v2/dependencies.txt_ and _v2/build-dependencies.txt_.
-
-Then amend the `CRAN_DATE` and `REPOS` arguments in _v2/env_.
-
-To update run
-
-```sh
-just build v2
-```
-
-To test the updated image run
-
-```sh
-just test v2
-```
-
-### How to choose a version of R and CRAN date
-
-Choose a version of R.
-
-Choose a CRAN date when that version of R.
-
-We follow a very similar approach to the versioned stack of the Rocker project. They list their R versions and CRAN dates on their [wiki](https://github.com/rocker-org/rocker-versioned2/wiki/Versions).
-
-We recommend not choosing a date within the first week of a new version of R being released, because there may be alot of packages updated on CRAN during this time.
-
-You then need to check that a PPPM snapshot repository exists for your chosen date. Navigate to <https://p3m.dev/client/#/repos/cran/setup> and inspect your chosen date. Set this date as the `REPOS` argument in _v2/env_.
-
-If you choose a version of R that is not the current version of R we recommend following the Rocker approach and choosing the CRAN date as the day before the next version of R was released. For example, if choosing R 4.4.1, R 4.4.2 was released on 2024-10-31 therefore we would choose 2024-10-30 as the CRAN date. Or as is the case here we are using the current version of R (4.4.2) therefore we choose the latest available date on PPPM as the CRAN date.
-
-You can find out when the next release of R is scheduled for on the [R developer page](https://developer.r-project.org/).
-
-We set the `HTTPUserAgent` in the appropriate places so that we obtain binary R packages for Linux from the PPPM. There is additional information about this on the [PPPM website](https://p3m.dev/__docs__/admin/serving-binaries/#binary-user-agents).
-
-## Differences between packages included in the v1 and v2 images
-
-In v2, compared to v1, several packages have either been superseeded by other packages or have been removed from CRAN. These include dummies, maptools (if required terra could be provided as a replacement), mnlogit, rgdal, and rgeos (the sf package is still included which acts as a replacement for rgdal and rgeos). Several additional packages such as sjPlot have been provided due to requests.
+We also add additional operating system libraries on user request.

--- a/scripts/build-toml.R
+++ b/scripts/build-toml.R
@@ -1,17 +1,6 @@
 REPOS <- Sys.getenv("REPOS")
 CRAN_DATE <- Sys.getenv("CRAN_DATE")
 
-# Set HTTPUserAgent so that PPPM serves binary R packages for Linux
-options(HTTPUserAgent = sprintf(
-  "R/%s R (%s)", getRversion(),
-  paste(
-    getRversion(),
-    R.version["platform"],
-    R.version["arch"],
-    R.version["os"]
-  )
-))
-
 install.packages("pak", repos = c(CRAN = REPOS), destdir = "/cache")
 
 # Set pak to use PPPM CRAN snapshot repository

--- a/scripts/local-packages-README.md
+++ b/scripts/local-packages-README.md
@@ -1,0 +1,32 @@
+# .local-packages a directory for user installed libraries
+
+This directory contains user installed libraries, for say use running OpenSAFELY code in a Codespace or locally.
+
+## How to add and remove user installed R packages
+
+The _.local-packages/r/v2_ directory contains user installed R packages to work in the `r:v2` and `rstudio:v2` images.
+
+You can install additional packages by running
+
+```r
+install.packages("PACKAGENAME")
+```
+
+or by using the RStudio _Package_ pane _Install_ button.
+
+Note that packages are installed from the same date from CRAN as the other packages in the `r:v2` image. This is to ensure user installed packages work with the other packages in the image (at the time of installation).
+
+If you no longer require a package you can also remove it as follows.
+
+```r
+remove.packages("PACKAGENAME")
+```
+
+You can also install packages from Git repositories such as GitHub, install the remotes package first as follows.
+
+```r
+install.packages("remotes")
+remotes::install_github("USERNAME/PACKAGENAME")
+```
+
+Please see the [r-docker repository README](https://github.com/opensafely-core/r-docker?tab=readme-ov-file#r-docker) if you require more information.

--- a/scripts/rprofile-site-append-1.R
+++ b/scripts/rprofile-site-append-1.R
@@ -1,0 +1,16 @@
+# Set the repository to download R packages from to be the PPPM CRAN snapshot at the chosen date
+# Set HTTPUserAgent so that PPPM serves binary R packages for Linux in an R terminal session
+# Note that RStudio (and rstudio-server) set this by default
+options(
+  repos = c(CRAN = Sys.getenv("REPOS")),
+  HTTPUserAgent = sprintf(
+    'R/%s R (%s)',
+    getRversion(),
+    paste(
+      getRversion(),
+      R.version['platform'],
+      R.version['arch'],
+      R.version['os']
+    )
+  )
+)

--- a/scripts/rprofile-site-append-2.R
+++ b/scripts/rprofile-site-append-2.R
@@ -1,0 +1,23 @@
+# If the local package directory exists set as first entry of R's library path
+# This is so that install.packages() and remove.packages() will use this directory by default.
+if (dir.exists('/workspace/.local-packages/r/v2'))
+  .libPaths(c('/workspace/.local-packages/r/v2', .libPaths()))
+
+# Monkey patch install.packages to create local package directory if it doesn't exist and
+# create a .gitignore file within in and copy in the README.md.
+# In R ... passes function arguments through to a subsequent call.
+install.packages <- function(...) {
+  if (!dir.exists("/workspace/.local-packages/r/v2")) {
+    dir.create("/workspace/.local-packages/r/v2", recursive = TRUE)
+    .libPaths(c("/workspace/.local-packages/r/v2", .libPaths()))
+    # create .gitignore file
+    file.create("/workspace/.local-packages/.gitignore")
+    fileconn <- file("/workspace/.local-packages/.gitignore")
+    writeLines("*", fileconn)
+    close(fileconn)
+  }
+  if (!file.exists("/workspace/.local-packages/README.md")) {
+      file.copy("/usr/local-packages-README.md", "/workspace/.local-packages/README.md")
+  }
+  utils::install.packages(...)
+}

--- a/tests/test-arrow.R
+++ b/tests/test-arrow.R
@@ -1,0 +1,2 @@
+library(arrow)
+arrow_info()

--- a/tests/test-number-packages.R
+++ b/tests/test-number-packages.R
@@ -1,0 +1,1 @@
+print(paste('Total number of R packages:', nrow(installed.packages())))

--- a/tests/test-preinstalled-user-package-step-1.R
+++ b/tests/test-preinstalled-user-package-step-1.R
@@ -1,0 +1,7 @@
+# .libPaths() should not have been amended yet
+stopifnot(.libPaths()[1] != "/workspace/.local-packages/r/v2")
+# install package to user library in repo
+install.packages("tmsens")
+# .libPaths() should have been amended
+stopifnot(.libPaths()[1] == "/workspace/.local-packages/r/v2")
+print("Step 1: installing user package and amending .libPaths() paths test passed")

--- a/tests/test-preinstalled-user-package-step-2.R
+++ b/tests/test-preinstalled-user-package-step-2.R
@@ -1,0 +1,7 @@
+# User library directory should already exist, hence .libPaths() is amended
+stopifnot(.libPaths()[1] == "/workspace/.local-packages/r/v2")
+# Load the pre-installed package from previous R session which is now in repo
+library(tmsens)
+# Delete /workspace/.local-packages
+unlink('/workspace/.local-packages', recursive = TRUE)
+print("Step 2: Loading a pre-installed user package in a different R session test passed.")

--- a/tests/test-rcpp.R
+++ b/tests/test-rcpp.R
@@ -1,0 +1,2 @@
+stopifnot(is.numeric(Rcpp::evalCpp('2 + 2')))
+print('Rcpp test passed')

--- a/tests/test-user-install-package.R
+++ b/tests/test-user-install-package.R
@@ -1,0 +1,66 @@
+# Delete /workspace/.local-packages if it exists
+unlink('/workspace/.local-packages', recursive = TRUE)
+
+# Test settings
+print("Library paths settings checks")
+
+print("repos setting:")
+print(getOption("repos"))
+stopifnot(getOption("repos") == Sys.getenv("REPOS"))
+
+print("HTTPUserAgent setting:")
+print(getOption('HTTPUserAgent'))
+stopifnot(
+  getOption("HTTPUserAgent") ==
+    sprintf(
+      "R/%s R (%s)",
+      getRversion(),
+      paste(
+        getRversion(),
+        R.version["platform"],
+        R.version["arch"],
+        R.version["os"]
+      )
+    )
+)
+
+# Test installing then removing a package to user library directory
+# I have chosen the tmsens package because it has no hard dependencies
+# (i.e., no other packages get installed along with it)
+install.packages("tmsens")
+print("Installation test passed.")
+# Test loading that package
+library(tmsens)
+print("Loading user installed package test passed.")
+
+print("Library paths")
+stopifnot(.libPaths()[1] == "/workspace/.local-packages/r/v2")
+
+# Test adding a second package works
+# (again bpbounds chosen because it also has no hard dependencies)
+install.packages("bpbounds")
+library(bpbounds)
+print("Test installing a second package passed.")
+
+# Test adding a package which needs compilation
+# Note this will be downloaded as precompiled from PPPM
+# Again chosen because pak's 2 hard dependencies are base R packages
+# and hence are already installed.
+install.packages("pak")
+library(pak)
+print("Test installing and loading a package which needs compilation passed.")
+
+# Test uninstalling packages
+detach(package:tmsens)
+detach(package:bpbounds)
+detach(package:pak)
+remove.packages(c("tmsens", "bpbounds", "pak"))
+print("Test uninstalling user installed packages passed.")
+
+# Test .local-packages/README.md exists
+stopifnot(file.exists("/workspace/.local-packages/README.md"))
+
+# Delete /workspace/.local-packages
+unlink('/workspace/.local-packages', recursive = TRUE)
+
+print("Installing and removing a user installed package tests passed.")

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -2,23 +2,41 @@
 set -eu
 MAJOR_VERSION=${1}
 
+trap "rm -rf .tests.R .local-packages || true" EXIT
+
+run_test() {
+  MAJOR_VERSION=$1
+  TEST_SCRIPT=$2
+  docker run --platform linux/amd64 --env-file "${MAJOR_VERSION}"/env --rm -v "${PWD}:/workspace" r:"${MAJOR_VERSION}" "${TEST_SCRIPT}"
+}
+
 if [ "${MAJOR_VERSION}" = "v1" ]; then
   # Test all R packages can be loaded
   python3 -c "import json; print('\n'.join(json.load(open(\"./$MAJOR_VERSION/renv.lock\"))['Packages']))" | xargs -I {} echo "if (!library({}, warn.conflicts = FALSE, logical.return = TRUE)) {stop(\"Package {} failed to load, please investigate\")}" > .tests.R
-  docker run --platform linux/amd64 --rm -v "$PWD:/tests/" r:${MAJOR_VERSION} /tests/.tests.R
+  run_test "${MAJOR_VERSION}" .tests.R
 elif [ "${MAJOR_VERSION}" = "v2" ]; then
   # Test all R packages can be attached then detached
-  docker run --platform linux/amd64 --env-file ${MAJOR_VERSION}/env --rm -v "${PWD}:/tests" r:"${MAJOR_VERSION}" /tests/tests/test-loading-packages.R
+  run_test "${MAJOR_VERSION}" ./tests/test-loading-packages.R
 fi
 
 # Check that a basic Rcpp call runs successfully
-docker compose --env-file ${MAJOR_VERSION}/env run --rm r -e "if (is.numeric(Rcpp::evalCpp('2 + 2'))) {print('Rcpp test passed')}"
+run_test "${MAJOR_VERSION}" ./tests/test-rcpp.R
 
 # Check number of packages
-docker compose --env-file ${MAJOR_VERSION}/env run --rm r -e "print(paste('Total number of R packages:', nrow(installed.packages())))"
+run_test "${MAJOR_VERSION}" ./tests/test-number-packages.R
 
 # Check capabilities of arrow package
-docker compose --env-file ${MAJOR_VERSION}/env run --rm r -e "arrow::arrow_info()"
+run_test "${MAJOR_VERSION}" ./tests/test-arrow.R
 
 # Test loading the 14 base packages
-docker run --platform linux/amd64 --env-file ${MAJOR_VERSION}/env --rm -v "${PWD}:/tests" r:"${MAJOR_VERSION}" /tests/tests/test-loading-base.R
+run_test "${MAJOR_VERSION}" ./tests/test-loading-base.R
+
+# Test user installed paackages on v2
+if [ "${MAJOR_VERSION}" = "v2" ]; then
+  # Test installing and loading in same R session
+  run_test "${MAJOR_VERSION}" ./tests/test-user-install-package.R
+  
+  # Test installing and loading in different R sessions
+  run_test "${MAJOR_VERSION}" ./tests/test-preinstalled-user-package-step-1.R
+  run_test "${MAJOR_VERSION}" ./tests/test-preinstalled-user-package-step-2.R
+fi

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -25,13 +25,18 @@ ARG CRAN_DATE="default-arg-to-silence-docker"
 RUN --mount=type=cache,target=/cache,id=/cache-2204,sharing=locked \
     --mount=type=bind,source=scripts/build-toml.R,target=/tmp/scripts/build-toml.R \
     --mount=type=bind,source=${MAJOR_VERSION}/packages.toml,target=/tmp/packages.toml \
+    --mount=type=bind,source=scripts/rprofile-site-append-1.R,target=/tmp/rprofile-site-append-1.R  <<EOF
+    echo "REPOS=${REPOS}" >> /usr/lib/R/etc/Renviron.site
+    cat /tmp/rprofile-site-append-1.R >> /usr/lib/R/etc/Rprofile.site
     Rscript /tmp/scripts/build-toml.R
+EOF
 
 
 ################################################
 #
 # Finally, build the actual image from the base-r image
 FROM base-r AS r
+ARG REPOS="default-arg-to-silence-docker"
 
 # Some static metadata for this specific image, as defined by:
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys
@@ -54,6 +59,10 @@ ENV INTERACTIVE_EXEC="/usr/bin/R"
 RUN mkdir /workspace
 WORKDIR /workspace
 
+# Settings to make it easier for users to add packages
+RUN --mount=type=bind,source=scripts/rprofile-site-append-2.R,target=/tmp/rprofile-site-append-2.R \
+    cat /tmp/rprofile-site-append-2.R >> /usr/lib/R/etc/Rprofile.site
+COPY scripts/local-packages-README.md /usr/local-packages-README.md
 
 #################################################
 #


### PR DESCRIPTION
In this, users can now add packages which are saved into their research repository by calling `install.packages("PACKAGENAME")` as they are used to in their local versions of R.

It works by

* If a repo contains a _.local-packages/r/v2_ directory (seen as _/workspace/.local-packages/r/v2_ within the image) then R's library paths are amended such that this is the first entry. This means users can load any pre-saved packages with `library(PACKAGENAME)` as usual.
* If a repo does not yet contain this directory then the library paths are only amended when `install.packages("PACKAGENAME")` is called.
* The `install.packages()` function has been overwritten/monkey patched with the ability to create _.local-packages/r/v2_ if it doesn't exist and then amend R's library paths with this as the first entry, add a _README.md_ file to _.local-packages_, and then install the requested package/s as usual.
* R's `repos` option is set to the same public Posit Package Manager (PPPM) snapshot repository which we installed the other packages from during the Docker build. This means user requested packages will be installed at a version consistent with the other packages in the v2 image. Users can override the `install.packages()` `repos` argument if they really must a different version.
* The `HTTPUserAgent` option is set in both terminal and RStudio Server sessions (i.e., in `rstudio:v2`), so that binary Linux R packages are obtained from PPPM when the user runs `install.packages("PACKAGENAME")`.

Closes #176 